### PR TITLE
feat: isLimited:false during dev

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -37,6 +37,7 @@ const Home: NextPage = () => {
   const isW3iInitialized = useInitWeb3InboxClient({
     projectId,
     domain: appDomain,
+    isLimited: process.env.NODE_ENV == "production",
   });
   const {
     account,


### PR DESCRIPTION
Untested, plz test @boidushya 

This sets `isLimited:false` during development so that localhost is allowed to manage the deployed did.json's subscriptions. When deployed, it's `true` as it is by default.

Preferred over `isLimited: appDomain == window.location.host` as to not imply that `isLimited:false` should be normally used in production for single-domain apps.